### PR TITLE
Add destdir support to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 CC = gcc #/usr/local/bin/gcc-4.2
+PREFIX = /usr/local
 NDEBUG ?= 
 CFLAGS = -c -std=c99 -Wall -Werror -Wno-unused-variable -Wno-format-security -O3 -static $(NDEBUG) 
 SRCS = src/carp_instructions.c src/carp_lexer.c src/carp_machine.c src/carp_tokenizer.c src/lib/carp_stack.c src/lib/carp_ht.c
@@ -10,7 +11,6 @@ all:
 	$(CC) $(CFLAGS) $(SRCS)
 	ar cr libcarp.a $(OBJS)
 	$(CC) src/carp.c libcarp.a -o $(PROG)
-	make clean_objs
 
 #.PHONY: tests
 
@@ -18,17 +18,19 @@ all:
 #	gcc tests/stack.c libcarp.a ../libtap/tap.c -o tests/stack
 
 uninstall:
-	rm -rf /usr/local/include/carp
-	rm -f /usr/local/lib/libcarp.a
-	rm -f /usr/local/bin/$(PROG)
+	rm $(DESTDIR)$(PREFIX)/include/carp
+	rm $(DESTDIR)$(PREFIX)/lib/libcarp.a
+	rm $(DESTDIR)$(PREFIX)/bin/$(PROG)
 
 install:
-	make uninstall
-	mkdir -p /usr/local/include/carp/lib
-	cp src/*.h /usr/local/include/carp
-	cp src/lib/*.h /usr/local/include/carp/lib
-	cp libcarp.a /usr/local/lib
-	cp $(PROG) /usr/local/bin/carp
+	test -d ${DESTDIR}${PREFIX}/bin || mkdir -p ${DESTDIR}${PREFIX}/bin
+	test -d ${DESTDIR}${PREFIX}/lib || mkdir -p ${DESTDIR}${PREFIX}/lib
+	test -d ${DESTDIR}${PREFIX}/include/carp || mkdir -p ${DESTDIR}${PREFIX}/carp
+	test -d ${DESTDIR}${PREFIX}/include/carp/lib || mkdir -p $(DESTDIR)$(PREFIX)/include/carp/lib
+	cp src/*.h $(DESTDIR)$(PREFIX)/include/carp
+	cp src/lib/*.h $(DESTDIR)$(PREFIX)/include/carp/lib
+	cp libcarp.a $(DESTDIR)$(PREFIX)/lib
+	install -pm 755 $(PROG) $(DESTDIR)$(PREFIX)/bin/carp
 
 clean_libs:
 	find . -name "*.a"	\


### PR DESCRIPTION
Much nicer to use for systems that use another prefix than /usr/local. 
Destdir support adds possible support for package managers like pkgsrc.
