### PR TITLE
Fixed syntax error in example in SYNTAX.md

### DIFF
--- a/SYNTAX.md
+++ b/SYNTAX.md
@@ -13,14 +13,14 @@ Example:
 
 ```asm
 add:
-	gloadi -5
-	gloadi -4
-	addi
+	gload -5
+	gload -4
+	add
 	ret
 
 main:
-	pushi 7
-	pushi 9
+	push 7
+	push 9
 	call @add, 2
 	ptop
 	halt 0


### PR DESCRIPTION
Original syntax example in SYNTAX.md gave `Unknown token <gloadi>` when run.
