### PR TITLE
attempt to fix compiler errors on cygwin

### DIFF
--- a/src/carp_tokenizer.c
+++ b/src/carp_tokenizer.c
@@ -156,10 +156,10 @@ carp_bool is_sign (char c) {
 carp_bool is_num (const char *s) {
   assert(s != NULL);
 
-  if (!(is_sign(s[0]) || isdigit((int) s[0]))) return 0;
+  if (!(is_sign(s[0]) || isdigit((unsigned char) s[0]))) return 0;
 
   for (int i = 1; i < strlen(s); i++)
-    if (!isdigit((int) s[i])) return 0;
+    if (!isdigit((unsigned char) s[i])) return 0;
 
   return 1;
 }


### PR DESCRIPTION
I think this should do it, as per that stack overflow link. Unless your earlier cast to `int` fixed the problem?
