### PR TITLE
docs: fix simple typo, thuogh -> though

### DIFF
--- a/SYNTAX.md
+++ b/SYNTAX.md
@@ -7,7 +7,7 @@ Subject to change:
 1. Function definitions are defined with a colon at the end of the name, like so: `add:`.
 2. Function calls are simple: `call add, 2`.
 3. Registers are not prefixed with %, like so: `ax`.
-4. Instruction arguments are separated by commas (thuogh actually they don't have to be).
+4. Instruction arguments are separated by commas (though actually they don't have to be).
 5. All words must be shorter than 10 characters long.
 6. All Carp files must end with a blank line.
 

--- a/src/machine.c
+++ b/src/machine.c
@@ -125,7 +125,7 @@ void carp_vm_err (carp_machine_state *m, const char *e) {
 }
 
 /*
-  Free the code, stack, varible table, and label table.
+  Free the code, stack, variable table, and label table.
 */
 void carp_vm_cleanup (carp_machine_state *m) {
   assert(m != NULL);


### PR DESCRIPTION
There is a small typo in SYNTAX.md.

Should read `though` rather than `thuogh`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md